### PR TITLE
Python installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Alpha Python Instructions
 
 Below are instructions for an alpha-release of a simple c-types python wrapper for this C++ code. Only Unix type systems are currently supported. 
 
-NB: ubuntu requires `sudo apt install clang libc++-dev g++` 
+NB: ubuntu requires `sudo apt install clang g++` 
 
 Within terminal, clone this repo and run the make script: 
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Alpha Python Instructions
 
 Below are instructions for an alpha-release of a simple c-types python wrapper for this C++ code. Only Unix type systems are currently supported. 
 
+NB: ubuntu requires `sudo apt install clang libc++-dev g++` 
+
 Within terminal, clone this repo and run the make script: 
 
 ```

--- a/python/FastLZeroSpikeInference/fast.py
+++ b/python/FastLZeroSpikeInference/fast.py
@@ -6,19 +6,26 @@ import sys
 
 sys_path = sys.path
 success = False
-i = 0
-n_paths = len(sys_path)
 
-while(not success & (i < n_paths)):
-	try: 
-		lib = np.ctypeslib.load_library('FastLZeroSpikeInference', sys_path[i])
-		success = True
-		break
-	except:
-		i = i + 1
+for path in sys_path:
+    try:
+        lib = np.ctypeslib.load_library('FastLZeroSpikeInference', path)
+        success = True
+        break
+    except OSError as err:
+        if '{0}'.format(err) == 'no file with expected extension':
+            e = err
+            continue
+        else:
+            print("OSError: {0}".format(err))
+            raise
+    except:
+        print("Unexpected error:", sys.exc_info()[0])
+        raise
 
-if not success:
-	raise Exception("Could not import required library")
+assert success, "Failed to import 'FastZeroSpikeInference'"
+
+
 
 def arfpop(dat, gam, penalty, constraint):
 	dat = np.ascontiguousarray(dat, dtype = float)

--- a/python/FastLZeroSpikeInference/fast.py
+++ b/python/FastLZeroSpikeInference/fast.py
@@ -23,7 +23,7 @@ for path in sys_path:
         print("Unexpected error:", sys.exc_info()[0])
         raise
 
-assert success, "Failed to import 'FastZeroSpikeInference'"
+assert success, "Failed to import 'FastZeroSpikeInference': {}".format(e)
 
 
 

--- a/python/make.sh
+++ b/python/make.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-mkdir src
-cp -r ../src/ src/
+cp -r ../src ./
 python setup.py install
 rm -r src  

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
 import os
+import sys
 from distutils.core import setup, Extension
 
 os.environ["CC"] = "clang++"
+
+is_darwin = sys.platform=='darwin'
 
 setup(name='FastLZeroSpikeInference',
       version='1.0',
@@ -11,7 +14,21 @@ setup(name='FastLZeroSpikeInference',
       author_email='swjewell@uw.edu',
       url='https://github.com/jewellsean/FastLZeroSpikeInference',
       packages=['FastLZeroSpikeInference'],
-      ext_modules=[Extension(name = 'FastLZeroSpikeInference', sources = ['src/funPieceListLog.cpp', 'src/ARFPOP.cpp', 'src/IsotonicFPOP.cpp', 'src/interface.cpp'],
-      						include_dirs = ['src/'], language = 'c++',
-      						extra_compile_args = ['-std=c++11', '-stdlib=libc++'])]
+      ext_modules=[
+          Extension(
+              name = 'FastLZeroSpikeInference', 
+              sources = ['src/funPieceListLog.cpp', 
+                         'src/ARFPOP.cpp', 
+                         'src/IsotonicFPOP.cpp', 
+                         'src/interface.cpp'
+                         ],
+              include_dirs = ['src/'], 
+              language = 'c++',
+              extra_compile_args = [
+                  '-std=c++11', 
+                  '-stdlib={}'.format('libc++' if is_darwin else 'libstdc++')
+                  ]
+              )
+          ]
      )
+


### PR DESCRIPTION
1. `make.sh` : modified to fix missing `src` files
2. `README.md` : added ubuntu dependencies 
3. `fast.py` : replaced (potentially) endless `while`-loop serving to import `FastLZeroSpikeInference`
4. `setup.py` : use `libc++` on mac, o/w use `libstdc++` ; corrected `README.md` accordingly